### PR TITLE
PointerAnalyzer::canBeCalledIndirectly now follows aliases

### DIFF
--- a/include/llvm/Duetto/PointerAnalyzer.h
+++ b/include/llvm/Duetto/PointerAnalyzer.h
@@ -100,6 +100,7 @@ public:
 
 #ifdef DUETTO_DEBUG_POINTERS
 	void dumpAllPointers() const;
+        void dumpAllFunctions() const;
 #endif //DUETTO_DEBUG_POINTERS
 	
 	// Return a string containing the type name of the object V.
@@ -131,10 +132,13 @@ public:
 	// Detect if a no-wrapping-array optimization is applicable to the pointer value
 	bool isNoWrappingArrayOptimizable(const llvm::Value * v) const;
 
-private:
 	// Detect if a function can possibly be called indirectly
 	bool canBeCalledIndirectly(const llvm::Function * f) const;
 
+private:
+	
+	bool computeCanBeCalledIndirectly(const llvm::Constant * c) const;
+	
 	typedef std::map<const llvm::Value *, POINTER_KIND> pointer_kind_map_t;
 	typedef std::map<const llvm::Value *, uint32_t> pointer_usage_map_t;
 	
@@ -142,9 +146,15 @@ private:
 	mutable pointer_usage_map_t pointerCompleteUsageMap;	
 	mutable pointer_usage_map_t pointerUsageMap;
 	
+	typedef std::map<const llvm::Function *, bool > function_indirect_call_map_t;
+	mutable function_indirect_call_map_t functionIndirectCallMap;
+	
 #ifdef DUETTO_DEBUG_POINTERS
 	typedef std::set<const llvm::Value *> known_pointers_t;
 	mutable known_pointers_t debugAllPointersSet;
+        
+        typedef std::set<const llvm::Function *> known_functions_t;
+        mutable known_functions_t debugAllFunctionsSet;
 #endif //DUETTO_DEBUG_POINTERS
 	
 	const NameGenerator & namegen;

--- a/lib/DuettoWriter/DuettoWriter.cpp
+++ b/lib/DuettoWriter/DuettoWriter.cpp
@@ -1620,20 +1620,30 @@ DuettoWriter::COMPILE_INSTRUCTION_FEEDBACK DuettoWriter::compileNotInlineableIns
 		case Instruction::Call:
 		{
 			const CallInst& ci=static_cast<const CallInst&>(I);
-			if(ci.getCalledFunction())
+			const Function * calledFunc = ci.getCalledFunction();
+	
+			// Try to resolve aliases
+			if (!calledFunc)
+				if(const GlobalAlias * a = dyn_cast<const GlobalAlias>(ci.getCalledValue()) )
+				{
+					const GlobalValue * gv = a->getAliasedGlobal();
+					assert( gv );
+					calledFunc = dyn_cast<const Function>( gv );
+				}
+			if(calledFunc)
 			{
 				//Direct call
-				const char* funcName=ci.getCalledFunction()->getName().data();
+				const char* funcName=calledFunc->getName().data();
 				COMPILE_INSTRUCTION_FEEDBACK cf=handleBuiltinCall(funcName,&ci,ci.op_begin(),
-						ci.op_begin()+ci.getNumArgOperands(),!ci.getCalledFunction()->empty());
+						ci.op_begin()+ci.getNumArgOperands(),!calledFunc->empty());
 				if(cf!=COMPILE_UNSUPPORTED)
 					return cf;
 				stream << '_' << funcName;
-				if(!globalsDone.count(ci.getCalledFunction()))
+				if(!globalsDone.count(calledFunc) )
 #ifdef DEBUG_GLOBAL_DEPS
-					globalsQueue.insert(make_pair(ci.getCalledFunction(),currentFun));
+					globalsQueue.insert(make_pair(calledFunc,currentFun));
 #else
-					globalsQueue.insert(ci.getCalledFunction());
+					globalsQueue.insert(calledFunc);
 #endif
 			}
 			else
@@ -1644,11 +1654,10 @@ DuettoWriter::COMPILE_INSTRUCTION_FEEDBACK DuettoWriter::compileNotInlineableIns
 			//If we are dealing with inline asm we are done
 			if(!ci.isInlineAsm())
 			{
-				const Function * f = ci.getCalledFunction();
-				if ( f && !f->isVarArg() )
+				if (calledFunc && !analyzer.canBeCalledIndirectly(calledFunc) && !calledFunc->isVarArg() )
 				{
-					assert( f->getArgumentList().size() == ci.getNumArgOperands() );
-					compileMethodArgsForDirectCall(ci.op_begin(),ci.op_begin()+ci.getNumArgOperands(),f->arg_begin() );
+					assert( calledFunc->getArgumentList().size() == ci.getNumArgOperands() );
+					compileMethodArgsForDirectCall(ci.op_begin(),ci.op_begin()+ci.getNumArgOperands(),calledFunc->arg_begin() );
 				}
 				else
 					compileMethodArgs(ci.op_begin(),ci.op_begin()+ci.getNumArgOperands());
@@ -3095,6 +3104,7 @@ void DuettoWriter::makeJS()
 	stream << "__Z7webMainv();\n";
 
 #ifdef DUETTO_DEBUG_POINTERS
+	analyzer.dumpAllFunctions();
 	analyzer.dumpAllPointers();
 #endif //DUETTO_DEBUG_POINTERS
 }


### PR DESCRIPTION
Check line DuettoWriter.cpp: 1630. Not entirely sure that assertion is always legitimately true.
